### PR TITLE
Default and pipeline

### DIFF
--- a/contrib/opencensus-ext-pymongo/opencensus/ext/pymongo/trace.py
+++ b/contrib/opencensus-ext-pymongo/opencensus/ext/pymongo/trace.py
@@ -24,7 +24,7 @@ log = logging.getLogger(__name__)
 
 MODULE_NAME = 'pymongo'
 
-COMMAND_ATTRIBUTES = ['filter', 'sort', 'skip', 'limit']
+COMMAND_ATTRIBUTES = ['filter', 'sort', 'skip', 'limit', 'pipeline']
 
 
 def trace_integration(tracer=None):

--- a/contrib/opencensus-ext-pymongo/tests/test_pymongo_trace.py
+++ b/contrib/opencensus-ext-pymongo/tests/test_pymongo_trace.py
@@ -44,6 +44,7 @@ class Test_pymongo_trace(unittest.TestCase):
             'filter': 'filter',
             'sort': 'sort',
             'limit': 'limit',
+            'pipeline': 'pipeline',
             'command_name': 'find'
         }
 
@@ -51,6 +52,7 @@ class Test_pymongo_trace(unittest.TestCase):
             'filter': 'filter',
             'sort': 'sort',
             'limit': 'limit',
+            'pipeline': 'pipeline',
             'request_id': 'request_id',
             'connection_id': 'connection_id'
         }


### PR DESCRIPTION
Add `pipeline` to Pymongo `COMMAND_ATTRIBUTES` to capture aggregations.

Skip `default=None` on `get` as we run into errors about that missing argument on some commands in production:

```
 TypeError: get() takes no keyword arguments 
 Traceback (most recent call last): 
   File "<REMOVED>/.virtualenv/lib/python3.7/site-packages/pymongo-3.6.1-py3.7-linux-x86_64.egg/pymongo/monitoring.py", line 739, in publish_command_start 
     subscriber.started(event) 
   File "<REMOVED>/.virtualenv/lib/python3.7/site-packages/opencensus_ext_pymongo-0.1.2-py3.7.egg/opencensus/ext/pymongo/trace.py", line 54, in started 
     _attr = event.command.get(attr, default=None) 
 TypeError: get() takes no keyword arguments 
```